### PR TITLE
match `DBInitInterrupts` without asm

### DIFF
--- a/libs/NdevExi2A/src/DebuggerDriver.c
+++ b/libs/NdevExi2A/src/DebuggerDriver.c
@@ -15,7 +15,7 @@ static OSInterruptHandler __DBMtrCallback;
 static u8 __DBReadUSB_CSR(void);
 static void __DBWaitForSendMail(void);
 
-void __DBMtrHandler(u32 type, OSContext* ctx) {
+void __DBMtrHandler(s32 type, OSContext* ctx) {
     __DBEXIInputFlag = TRUE;
 
     if (__DBMtrCallback != NULL)

--- a/libs/NdevExi2A/src/DebuggerDriver.c
+++ b/libs/NdevExi2A/src/DebuggerDriver.c
@@ -57,8 +57,9 @@ void DBInitComm(u8** flagOut, OSInterruptHandler handler) {
     OSRestoreInterrupts(enabled);
 }
 
-#if NON_MATCHING
-//https://decomp.me/scratch/YjmTr
+#pragma push
+#pragma optimization_level 0
+
 void DBInitInterrupts(void) {
     __OSMaskInterrupts(OS_INTR_MASK(OS_INTR_EXI_2_EXI) |
                        OS_INTR_MASK(OS_INTR_EXI_2_TC));
@@ -67,31 +68,8 @@ void DBInitInterrupts(void) {
     __OSSetInterruptHandler(OS_INTR_PI_DEBUG, __DBIntrHandler);
     __OSUnmaskInterrupts(OS_INTR_MASK(OS_INTR_PI_DEBUG));
 }
-#else 
-asm void DBInitInterrupts(void){
-    stwu r1, -0x10(r1)
-    mflr r0
-    lis r3, 2
-    stw r0, 0x14(r1)
-    addi r3, r3, -0x8000
-    bl __OSMaskInterrupts
-    li r3, 0x40
-    bl __OSMaskInterrupts
-    lis r3, __DBMtrHandler@ha
-    lis r4, __DBIntrHandler@ha
-    addi r3, r3, __DBMtrHandler@l
-    stw r3, __DBDbgCallback
-    addi r4, r4, __DBIntrHandler@l
-    li r3, 0x19
-    bl __OSSetInterruptHandler
-    li r3, 0x40
-    bl __OSUnmaskInterrupts
-    lwz r0, 0x14(r1)
-    mtlr r0
-    addi r1, r1, 0x10
-    blr 
-}
-#endif
+
+#pragma pop
 
 u32 DBQueryData(void) {
     __DBEXIInputFlag = FALSE;

--- a/libs/NdevExi2A/src/DebuggerDriver.c
+++ b/libs/NdevExi2A/src/DebuggerDriver.c
@@ -22,7 +22,7 @@ void __DBMtrHandler(u32 type, OSContext* ctx) {
         __DBMtrCallback(0, ctx);
 }
 
-void __DBIntrHandler(u32 type, OSContext* ctx) {
+void __DBIntrHandler(s32 type, OSContext* ctx) {
     PI_HW_REGS[PI_INTSR] = PI_INTSR_DEBUG;
     if (__DBDbgCallback != NULL)
         __DBDbgCallback(type, ctx);


### PR DESCRIPTION
Not sure why this works, but it does