### PR TITLE
CTaskGame::CTaskGame

### DIFF
--- a/src/kyoshin/CTaskGame.cpp
+++ b/src/kyoshin/CTaskGame.cpp
@@ -5,18 +5,14 @@ u32 lbl_80666624;
 u32 lbl_80666630;
 u32 lbl_80666634;
 
-__attribute__((noinline))
-void func_8004041C(
-    UnkClass_8004041C* self,
-    u8 r4, float f1, int r5, u32 r6, u8 r7, u32 r8, u32 r9)
-{
-    self->unk0  = r4;
-    self->unk4  = f1;
-    self->unk8  = r5;
-    self->unkC  = r6;
-    self->unk10 = r7;
-    self->unk14 = r8;
-    self->unk18 = r9;
+void UnkClass_8004041C::func_8004041C(u8 r4, float f1, int r5, u32 r6, u8 r7, u32 r8, u32 r9) {
+    this->unk0  = r4;
+    this->unk4  = f1;
+    this->unk8  = r5;
+    this->unkC  = r6;
+    this->unk10 = r7;
+    this->unk14 = r8;
+    this->unk18 = r9;
 }
 
 CTaskGame::CTaskGame(CView* pView, CWorkThread* pThread, int r6) :
@@ -57,7 +53,7 @@ CTaskGame::CTaskGame(CView* pView, CWorkThread* pThread, int r6) :
     unk130(0),
     unk170(0),
     unk188(0) {
-    func_8004041C(&unk18C, 0, -1, 2, 0, 0, 0, 1);
+    unk18C.func_8004041C(0, -1, 2, 0, 0, 0, 1);
     spInstance = this;
     CTaskGame_cLoadInstance = nullptr;
     lbl_80666624 = 0;

--- a/src/kyoshin/CTaskGame.cpp
+++ b/src/kyoshin/CTaskGame.cpp
@@ -5,6 +5,20 @@ u32 lbl_80666624;
 u32 lbl_80666630;
 u32 lbl_80666634;
 
+__attribute__((noinline))
+void func_8004041C(
+    UnkClass_8004041C* self,
+    u8 r4, float f1, int r5, u32 r6, u8 r7, u32 r8, u32 r9)
+{
+    self->unk0  = r4;
+    self->unk4  = f1;
+    self->unk8  = r5;
+    self->unkC  = r6;
+    self->unk10 = r7;
+    self->unk14 = r8;
+    self->unk18 = r9;
+}
+
 CTaskGame::CTaskGame(CView* pView, CWorkThread* pThread, int r6) :
     unk68(0),
     unk6C(pThread),
@@ -42,8 +56,8 @@ CTaskGame::CTaskGame(CView* pView, CWorkThread* pThread, int r6) :
     unk128(0),
     unk130(0),
     unk170(0),
-    unk188(0),
-    unk18C(0, -1, 2, 0, 0, 0, 1) {
+    unk188(0) {
+    func_8004041C(&unk18C, 0, -1, 2, 0, 0, 0, 1);
     spInstance = this;
     CTaskGame_cLoadInstance = nullptr;
     lbl_80666624 = 0;
@@ -52,7 +66,7 @@ CTaskGame::CTaskGame(CView* pView, CWorkThread* pThread, int r6) :
 }
 
 CTaskGame::~CTaskGame(){
-    
+    spInstance = nullptr;
 }
 
 CTaskGame* CTaskGame::getInstance(){

--- a/src/kyoshin/CTaskGame.hpp
+++ b/src/kyoshin/CTaskGame.hpp
@@ -19,6 +19,8 @@ public:
 };
 
 struct UnkClass_8004041C{
+    void func_8004041C(u8 r4, float f1, int r5, u32 r6, u8 r7, u32 r8, u32 r9);
+
     u8 unk0;
     float unk4;
     int unk8;

--- a/src/kyoshin/CTaskGame.hpp
+++ b/src/kyoshin/CTaskGame.hpp
@@ -19,16 +19,6 @@ public:
 };
 
 struct UnkClass_8004041C{
-    UnkClass_8004041C(u8 r4, int r5, u32 r6, u8 r7, u32 r8, u32 r9, float f1){
-        unk0 = r4;
-        unk4 = f1;
-        unk8 = r5;
-        unkC = r6;
-        unk10 = r7;
-        unk14 = r8;
-        unk18 = r9;
-    }
-
     u8 unk0;
     float unk4;
     int unk8;


### PR DESCRIPTION
The constructor of CTaskGame::CTaskGame is at around ~70% matching because of a constructor of an unk class which the compiler inlines, unlike the original code which calls it as a function.
By removing the constructor from the unk class and rather having a separate function just as the original code, the matching increases up to 94.66%.