### PR TITLE
config/us/splits.txt: carve g3d_anmclr's per-TU data ranges

### DIFF
--- a/config/us/splits.txt
+++ b/config/us/splits.txt
@@ -3295,14 +3295,20 @@ criware_data.s:
 	.data       start:0x80560028 end:0x80568F38
 	.bss        start:0x805DFDA8 end:0x8061A4D8
 
-nw4r_data.s:
-	.rodata     start:0x8051D4A0 end:0x80522410
-	.data       start:0x80568F38 end:0x8056B0E0
+nw4r_dataa.s:
+	.rodata     start:0x8051D4A0 end:0x8051D530
+	.data       start:0x80568F38 end:0x80569180
 	.bss        start:0x8061A4D8 end:0x80653EE0
-	.sdata      start:0x80663450 end:0x80663500
+	.sdata      start:0x80663450 end:0x80663458
 	.sbss       start:0x80665438 end:0x80665570
-	.sdata2     start:0x80669A68 end:0x8066A178
+	.sdata2     start:0x80669A68 end:0x80669B48
 	.sbss2      start:0x8066B550 end:0x8066B558
+
+nw4r_datab.s:
+	.rodata     start:0x8051D560 end:0x80522410
+	.data       start:0x80569210 end:0x8056B0E0
+	.sdata      start:0x80663460 end:0x80663500
+	.sdata2     start:0x80669B58 end:0x8066A178
 
 monolibdata1.s:
 	.rodata     start:0x80522410 end:0x80522990
@@ -3843,6 +3849,10 @@ nw4r/src/g3d/g3d_anmvis.cpp:
 
 nw4r/src/g3d/g3d_anmclr.cpp:
 	.text       start:0x803E3F4C end:0x803E4CD0
+	.rodata     start:0x8051D530 end:0x8051D560
+	.data       start:0x80569180 end:0x80569210
+	.sdata      start:0x80663458 end:0x80663460
+	.sdata2     start:0x80669B48 end:0x80669B58
 
 nw4r/src/g3d/g3d_anmtexpat.cpp:
 	.text       start:0x803E4CD0 end:0x803E56FC


### PR DESCRIPTION
## Summary

Enables a future `nw4r/src/g3d/g3d_anmclr.cpp` flip to Matching by giving the TU its own `.rodata` / `.data` / `.sdata` / `.sdata2` ranges. Without these, source-emitted symbols in `g3d_anmclr.cpp` would collide with `nw4r_data.o`'s catch-all blob and fail to link.

## Two coordinated edits

### 1. Split `nw4r_data.s` into `nw4r_dataa.s` + `nw4r_datab.s`

Multi-pseudo-unit (same pattern as `split1a`/`b`/`c`/`d` elsewhere in this file). Needed because the carve fragments 4 sections; a single pseudo-unit would create a cyclic linker dependency across the carved range.

- `nw4r_dataa.s` holds ranges below `g3d_anmclr`'s carve.
- `nw4r_datab.s` holds ranges above.
- `.bss` / `.sbss` / `.sbss2` don't need carving (no overlap with `g3d_anmclr`'s data), so they live only in `nw4r_dataa.s`.

### 2. Add 4 per-TU ranges to `nw4r/src/g3d/g3d_anmclr.cpp`

Matches JP's per-TU shape exactly:

| Section | Range | Size |
|---|---|---|
| `.rodata` | `0x8051D530`..`0x8051D560` | 48 bytes |
| `.data` | `0x80569180`..`0x80569210` | 144 bytes |
| `.sdata` | `0x80663458`..`0x80663460` | 8 bytes |
| `.sdata2` | `0x80669B48`..`0x80669B58` | 16 bytes |

## Impact

- DOL hash unchanged today: `214b15173fa3bad23a067476d58d3933ad7037b7` (verified locally).
- Concrete data-matching benefit once a `g3d_anmclr.cpp` port lands to claim the carved range: NW4R data matching jumps from **60/68 bytes (88.24%) → 276/284 bytes (97.18%)**.

## Test plan

- [x] Build with `python configure.py --version us && ninja` — clean, SHA-1 matches `214b15173fa3bad23a067476d58d3933ad7037b7`.
- [x] Diff is purely additive/refactor — no `.text` ranges moved.
- [x] Following established `split1a`/`b`/`c`/`d` multi-pseudo-unit pattern that's already in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)